### PR TITLE
Remove obsolete AppVeyor VersionPrefix from csproj

### DIFF
--- a/src/Autofac.Extensions.Hosting/Autofac.Extensions.Hosting.csproj
+++ b/src/Autofac.Extensions.Hosting/Autofac.Extensions.Hosting.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Description>Fluent configuration of Autofac with the Microsoft.Extensions.Hosting package.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary
- Removes the `<VersionPrefix>` property from the source .csproj
- Version is set by `default.proj` via `/p:Version` during GitHub Actions CI, making the csproj entry unnecessary
- Eliminates risk of accidentally building with a dummy version outside the normal pipeline

## Test plan
- [ ] CI build passes (version still correctly set by default.proj)
- [ ] Verify produced package has correct version suffix based on branch