### PR TITLE
Technology refresh: update target frameworks

### DIFF
--- a/src/Autofac.Extensions.Hosting/Autofac.Extensions.Hosting.csproj
+++ b/src/Autofac.Extensions.Hosting/Autofac.Extensions.Hosting.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Description>Fluent configuration of Autofac with the Microsoft.Extensions.Hosting package.</Description>
     <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Extensions.Hosting</AssemblyName>

--- a/src/Autofac.Extensions.Hosting/Autofac.Extensions.Hosting.csproj
+++ b/src/Autofac.Extensions.Hosting/Autofac.Extensions.Hosting.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Fluent configuration of Autofac with the Microsoft.Extensions.Hosting package.</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Extensions.Hosting</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Autofac.Extensions.Hosting</PackageId>
     <PackageTags>autofac;di;ioc;dependencyinjection;hosting</PackageTags>
     <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.Extensions.Hosting/releases</PackageReleaseNotes>

--- a/src/Autofac.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Autofac.Extensions.Hosting/HostBuilderExtensions.cs
@@ -6,42 +6,41 @@ using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Autofac.Extensions.Hosting
+namespace Autofac.Extensions.Hosting;
+
+/// <summary>
+/// Extension methods on <see cref="IHostBuilder"/> to register the <see cref="IServiceProviderFactory{TContainerBuilder}"/>.
+/// </summary>
+public static class HostBuilderExtensions
 {
     /// <summary>
-    /// Extension methods on <see cref="IHostBuilder"/> to register the <see cref="IServiceProviderFactory{TContainerBuilder}"/>.
+    /// Use the <see cref="AutofacServiceProviderFactory" /> as the factory for creating the service provider.
     /// </summary>
-    public static class HostBuilderExtensions
-    {
-        /// <summary>
-        /// Use the <see cref="AutofacServiceProviderFactory" /> as the factory for creating the service provider.
-        /// </summary>
-        /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
-        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
-        /// <returns>The same instance of the <see cref="IHostBuilder" /> for chaining.</returns>
-        public static IHostBuilder UseAutofac(this IHostBuilder hostBuilder, Action<ContainerBuilder> configurationAction = null)
-            => hostBuilder.UseServiceProviderFactory(new AutofacServiceProviderFactory(configurationAction));
+    /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
+    /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+    /// <returns>The same instance of the <see cref="IHostBuilder" /> for chaining.</returns>
+    public static IHostBuilder UseAutofac(this IHostBuilder hostBuilder, Action<ContainerBuilder> configurationAction = null)
+        => hostBuilder.UseServiceProviderFactory(new AutofacServiceProviderFactory(configurationAction));
 
-        /// <summary>
-        /// Use the <see cref="AutofacChildLifetimeScopeServiceProviderFactory" /> as the factory for creating the service provider.
-        /// </summary>
-        /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
-        /// <param name="containerAccessor">A function to retrieve the <see cref="IContainer"/> instance.</param>
-        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
-        /// <returns>The same instance of the <see cref="IHostBuilder" /> for chaining.</returns>
-        public static IHostBuilder UseAutofacChildLifetimeScopeFactory(this IHostBuilder hostBuilder, Func<IContainer> containerAccessor, Action<ContainerBuilder> configurationAction = null)
-            => hostBuilder.UseServiceProviderFactory(
-                new AutofacChildLifetimeScopeServiceProviderFactory(containerAccessor, configurationAction));
+    /// <summary>
+    /// Use the <see cref="AutofacChildLifetimeScopeServiceProviderFactory" /> as the factory for creating the service provider.
+    /// </summary>
+    /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
+    /// <param name="containerAccessor">A function to retrieve the <see cref="IContainer"/> instance.</param>
+    /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+    /// <returns>The same instance of the <see cref="IHostBuilder" /> for chaining.</returns>
+    public static IHostBuilder UseAutofacChildLifetimeScopeFactory(this IHostBuilder hostBuilder, Func<IContainer> containerAccessor, Action<ContainerBuilder> configurationAction = null)
+        => hostBuilder.UseServiceProviderFactory(
+            new AutofacChildLifetimeScopeServiceProviderFactory(containerAccessor, configurationAction));
 
-        /// <summary>
-        /// Use the <see cref="AutofacChildLifetimeScopeServiceProviderFactory" /> as the factory for creating the service provider.
-        /// </summary>
-        /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
-        /// <param name="container">The <see cref="IContainer"/> instance.</param>
-        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
-        /// <returns>The same instance of the <see cref="IHostBuilder" /> for chaining.</returns>
-        public static IHostBuilder UseAutofacChildLifetimeScopeFactory(this IHostBuilder hostBuilder, IContainer container, Action<ContainerBuilder> configurationAction = null)
-            => hostBuilder.UseServiceProviderFactory(
-                new AutofacChildLifetimeScopeServiceProviderFactory(container, configurationAction));
-    }
+    /// <summary>
+    /// Use the <see cref="AutofacChildLifetimeScopeServiceProviderFactory" /> as the factory for creating the service provider.
+    /// </summary>
+    /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
+    /// <param name="container">The <see cref="IContainer"/> instance.</param>
+    /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+    /// <returns>The same instance of the <see cref="IHostBuilder" /> for chaining.</returns>
+    public static IHostBuilder UseAutofacChildLifetimeScopeFactory(this IHostBuilder hostBuilder, IContainer container, Action<ContainerBuilder> configurationAction = null)
+        => hostBuilder.UseServiceProviderFactory(
+            new AutofacChildLifetimeScopeServiceProviderFactory(container, configurationAction));
 }

--- a/test/Autofac.Extensions.Hosting.Test/Autofac.Extensions.Hosting.Test.csproj
+++ b/test/Autofac.Extensions.Hosting.Test/Autofac.Extensions.Hosting.Test.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>Autofac.Extensions.DependencyInjection.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Autofac.Extensions.DependencyInjection.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>


### PR DESCRIPTION
## Summary
- Update source project to multi-target net10.0, net8.0, netstandard2.1, and netstandard2.0 (was netstandard2.0 only)
- Remove obsolete `PublicSign` property from both source and test projects (no longer needed for cross-platform strong naming)
- Test project already targeting net10.0

## Test plan
- [x] Build completes with zero warnings
- [x] All tests pass on net10.0